### PR TITLE
Enable escaping for hyphens

### DIFF
--- a/src/Alom/Graphviz/BaseInstruction.php
+++ b/src/Alom/Graphviz/BaseInstruction.php
@@ -62,6 +62,6 @@ abstract class BaseInstruction implements InstructionInterface
      */
     protected function needsEscaping($value)
     {
-        return preg_match('/[ "#:\\/\\.,]/', $value) || in_array($value, array('graph', 'node', 'edge')) || empty($value);
+        return preg_match('/[ "#-:\\/\\.,]/', $value) || in_array($value, array('graph', 'node', 'edge')) || empty($value);
     }
 }

--- a/tests/Alom/Graphviz/Tests/AssignTest.php
+++ b/tests/Alom/Graphviz/Tests/AssignTest.php
@@ -38,6 +38,9 @@ class AssignTest extends \PHPUnit_Framework_TestCase
         $assign = new Assign('foo', '#bar');
         $this->assertEquals("foo=\"#bar\";\n", $assign->render(), "Escaping");
 
+        $assign = new Assign('foo', 'a-b');
+        $this->assertEquals("foo=\"a-b\";\n", $assign->render(), "Escaping hyphens");
+
         $assign = new Assign('foo', 'bar');
         $this->assertEquals("foo=bar;\n", $assign->render(), "Render method with simple strings");
         $this->assertEquals("    foo=bar;\n", $assign->render(1), "Render method with indent");


### PR DESCRIPTION
When an attribute contains an hyphen (" - "), the string needs
to be escaped. If not, graphviz will throw a syntax error.
This diff enables the existing escaping methods whenever an hyphen
is present in the attribute.
It also adds a test to make sure this functionality is present.
