### PR TITLE
WIP Support for HTML labels

### DIFF
--- a/tests/Alom/Graphviz/Tests/NodeTest.php
+++ b/tests/Alom/Graphviz/Tests/NodeTest.php
@@ -19,4 +19,37 @@ class NodeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("A;\n", $node->render(), "Render basic");
     }
+
+    public function testTitle()
+    {
+        $node = new Node('B');
+        $node->attribute('label', 'normal label text');
+        $this->assertEquals("A;\n", $node->render(), "Render basic");
+    }
+
+    /**
+     * Test the record type label form.
+     *
+     * @see http://graphviz.org/content/node-shapes#record
+     */
+    public function testTitleRecord()
+    {
+        $node = new Node('B');
+        $node->attribute('label', '<f0> left|<f1> mid&#92; dle|<f2> right');
+        $node->attribute('shape', 'record');
+        $this->assertEquals("A;\n", $node->render(), "Render basic");
+    }
+
+    /**
+     * Test the HTML label form.
+     *
+     * @see http://graphviz.org/content/node-shapes#html
+     */
+    public function testTitleTable()
+    {
+        $node = new Node('B');
+        $node->attribute('label', '<<TABLE><TR><TD>left</TD><TD PORT="f1">mid dle</TD><TD PORT="f2">right</TD></TR></TABLE>>');
+        $this->assertEquals("A;\n", $node->render(), "Render basic");
+    }
+
 }


### PR DESCRIPTION
There currently is no support for HTML table labels http://graphviz.org/content/node-shapes#html 

I was curious for this support so wrote these small failing tests.

- [ ] Fix failing test for normal title (trivial to fix)
- [ ] Fix failing test for record title (is all escaping properly esp. ports: http://graphviz.org/content/node-shapes#record)
- [ ] Fix failing test for HTML title (this is tricky due to the current escaper)

Note I come from https://github.com/clue/graph-uml and https://github.com/clue/graph of which the latter has a graphviz rendering. The latter is about to split off graphviz into it's own project so maybe we can team-up ... not sure.

Feel free to close or fix for the tests :-)