### PR TITLE
Extremely simple work around to allow unescaped values.

### DIFF
--- a/src/Alom/Graphviz/BaseInstruction.php
+++ b/src/Alom/Graphviz/BaseInstruction.php
@@ -40,7 +40,10 @@ abstract class BaseInstruction implements InstructionInterface
      */
     protected function escape($value)
     {
-        return ($this->needsEscaping($value)) ? '"' . str_replace('"', '""', str_replace('\\', '\\\\', $value)) . '"' : $value;
+        if ($value[0] === chr(1))
+            return substr($value, 1);
+        else
+            return ($this->needsEscaping($value)) ? '"' . str_replace('"', '""', str_replace('\\', '\\\\', $value)) . '"' : $value;
     }
 
     protected function escapePath(array $path)

--- a/src/Alom/Graphviz/Node.php
+++ b/src/Alom/Graphviz/Node.php
@@ -64,11 +64,15 @@ class Node extends BaseInstruction
      *
      * @param string $name  Name of the attribute to set
      * @param string $value Value to set
+     * @param bool $escape
      *
      * @return \Alom\Graphviz\Node
      */
-    public function attribute($name, $value)
+    public function attribute($name, $value, $escape = true)
     {
+        if (!$escape)
+            $value = chr(1) . $value;
+        
         $this->attributes->set($name, $value);
 
         return $this;


### PR DESCRIPTION
This was a 5 mins 'hack'. Really tight on schedule, cannot provide tests etc.
Merge it or ignore it, your call, just pulling for other people who might be looking for a super quick no-escaping solution

Extremely simple to use
```php
            $graph->node($state['value'], [
                'label' => chr(1) . $label,
```