### PR TITLE
#13 Make keyword comparison case-insensitive

### DIFF
--- a/src/Alom/Graphviz/BaseInstruction.php
+++ b/src/Alom/Graphviz/BaseInstruction.php
@@ -68,6 +68,6 @@ abstract class BaseInstruction implements InstructionInterface
      */
     protected function needsEscaping($value)
     {
-        return preg_match('/[{} "#-:\\\\\\/\\.,]/', $value) || in_array($value, array('graph', 'node', 'edge')) || empty($value);
+        return preg_match('/[{} "#-:\\\\\\/\\.,]/', $value) || in_array(strtolower($value), array('graph', 'node', 'edge')) || empty($value);
     }
 }

--- a/tests/Alom/Graphviz/Tests/NodeTest.php
+++ b/tests/Alom/Graphviz/Tests/NodeTest.php
@@ -31,4 +31,10 @@ class NodeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('baz', $node->getAttribute('bar'));
     }
+
+    public function testRenderEscaped()
+    {
+        $node = new Node('Edge');
+        $this->assertEquals("\"Edge\";\n", $node->render(), 'Reserved keyword "Edge" escaped');
+    }
 }


### PR DESCRIPTION
`BaseInstruction::needsEscaping()` no longer case-sensitive when testing for reserved keywords